### PR TITLE
Use static linking by default for CocoaPods, add `--use_dynamic_linking` option.

### DIFF
--- a/uberpoet/cpprojectgen.py
+++ b/uberpoet/cpprojectgen.py
@@ -30,13 +30,14 @@ class CocoaPodsProjectGenerator(object):
     DIR_NAME = dirname(__file__)
     RESOURCE_DIR = join(DIR_NAME, "resources")
 
-    def __init__(self, app_root, use_wmo=False):
+    def __init__(self, app_root, use_wmo=False, use_dynamic_linking=False):
         self.app_root = app_root
         self.pod_lib_template = self.load_resource("mockcplibtemplate.podspec")
         self.pod_app_template = self.load_resource("mockcpapptemplate.podspec")
         self.podfile_template = self.load_resource("mockpodfile")
         self.swift_gen = SwiftFileGenerator()
         self.use_wmo = use_wmo
+        self.use_dynamic_linking = use_dynamic_linking
         self.swift_file_size_loc = None
         self.calculate_loc()
 
@@ -181,5 +182,7 @@ class CocoaPodsProjectGenerator(object):
 
     def gen_podfile(self, all_nodes):
         podfile_module_dep_list = self.make_podfile_dep_list([i.name for i in all_nodes])
+        link_style = ":dynamic" if self.use_dynamic_linking else ":static"
         return self.podfile_template.format(
-            "pod 'AppContainer', :path => 'App/AppContainer.podspec', :appspecs => ['App']", podfile_module_dep_list)
+            "pod 'AppContainer', :path => 'App/AppContainer.podspec', :appspecs => ['App']", podfile_module_dep_list,
+            link_style)

--- a/uberpoet/genproj.py
+++ b/uberpoet/genproj.py
@@ -57,6 +57,12 @@ class GenProjCommandLine(object):
             default=False,
             help='Whether or not to use whole module optimization when building swift modules.')
         parser.add_argument(
+            '-udl',
+            '--use_dynamic_linking',
+            default=False,
+            help='Whether or not to generate a project in which the modules are dynamically linked.  By default all '
+            'projects use static linking. This option is currently used only the CocoaPods generator.')
+        parser.add_argument(
             '--print_dependency_graph',
             default=False,
             help='If true, prints out the dependency edge list and exits instead of generating an application.')
@@ -110,7 +116,8 @@ def project_generator_for_arg(args):
         return blazeprojectgen.BlazeProjectGenerator(
             args.output_directory, args.blaze_module_path, use_wmo=args.use_wmo, flavor=args.project_generator_type)
     elif args.project_generator_type == 'cocoapods':
-        return cpprojectgen.CocoaPodsProjectGenerator(args.output_directory, use_wmo=args.use_wmo)
+        return cpprojectgen.CocoaPodsProjectGenerator(
+            args.output_directory, use_wmo=args.use_wmo, use_dynamic_linking=args.use_dynamic_linking)
     else:
         raise ValueError("Unknown project generator arg: " + str(args.project_generator_type))
 

--- a/uberpoet/resources/mockpodfile
+++ b/uberpoet/resources/mockpodfile
@@ -16,7 +16,7 @@
 # Check it out at https://github.com/uber/uber-poet
 
 platform :ios, '12.0'
-use_frameworks!
+use_frameworks!(:linkage => {2})
 inhibit_all_warnings!
 
 install! 'cocoapods', integrate_targets: false


### PR DESCRIPTION
It seems by default the Bazel rule uses static frameworks so this updates cocoapods to match this.

Default `false`:
![Screen_Shot_2021-05-25_at_3_08_42_PM](https://user-images.githubusercontent.com/310370/119575391-d9e8e000-bd6b-11eb-8c64-81abbf47bca9.png)

WIth `--use_dynamic_linking`:
<img width="1512" alt="Screen Shot 2021-05-25 at 3 10 13 PM" src="https://user-images.githubusercontent.com/310370/119575421-e4a37500-bd6b-11eb-8ed1-cde6848ff67a.png">

