### PR TITLE
Add support to print module_index within the generated project

### DIFF
--- a/tests/test_bazel_integration.py
+++ b/tests/test_bazel_integration.py
@@ -31,14 +31,14 @@ from .utils import integration_test, read_file
 
 class TestBazelIntegration(unittest.TestCase):
 
-    def verify_genproj(self, lib_name, mod_count, app_path):
+    def verify_genproj(self, lib_name, file_count, app_path):
         main_path = join(app_path, 'App')
         lib_path = join(app_path, lib_name, 'Sources')
 
         # Top level dir
         contents = os.listdir(app_path)
         self.assertGreater(len(contents), 0)
-        self.assertEqual(len(contents), mod_count)
+        self.assertEqual(len(contents), file_count)
 
         # App dir
         self.assertIn('App', contents)
@@ -70,7 +70,7 @@ class TestBazelIntegration(unittest.TestCase):
         command = GenProjCommandLine()
         command.main(args)
 
-        self.verify_genproj('MockLib53', 103, app_path)
+        self.verify_genproj('MockLib53', 104, app_path)
 
     @integration_test
     def test_dot_genproj(self):
@@ -85,7 +85,7 @@ class TestBazelIntegration(unittest.TestCase):
         command = GenProjCommandLine()
         command.main(args)
 
-        self.verify_genproj('DotReaderLib17', 340, app_path)
+        self.verify_genproj('DotReaderLib17', 341, app_path)
 
     @integration_test
     def test_dot_genproj_with_loc_mappings(self):
@@ -102,7 +102,7 @@ class TestBazelIntegration(unittest.TestCase):
         command = GenProjCommandLine()
         command.main(args)
 
-        self.verify_genproj('DotReaderLib17', 341, app_path)
+        self.verify_genproj('DotReaderLib17', 342, app_path)
 
     @integration_test
     def test_flat_multisuite(self):
@@ -114,7 +114,7 @@ class TestBazelIntegration(unittest.TestCase):
         command = CommandLineMultisuite()
         command.main(args)
         self.assertGreater(os.listdir(app_path), 0)
-        self.verify_genproj('MockLib53', 103, app_path)
+        self.verify_genproj('MockLib53', 104, app_path)
 
     @integration_test
     def test_flat_multisuite_mocking_calls(self):
@@ -147,7 +147,7 @@ class TestBazelIntegration(unittest.TestCase):
                 mock_find.return_value = '/bin/ls'  # A non empty return value basically means "I found that executable"
                 CommandLineMultisuite().main(args)
                 self.assertGreater(os.listdir(app_path), 0)
-                self.verify_genproj('MockLib53', 103, app_path)
+                self.verify_genproj('MockLib53', 104, app_path)
 
     @integration_test
     def test_dot_multisuite(self):
@@ -163,7 +163,7 @@ class TestBazelIntegration(unittest.TestCase):
         command = CommandLineMultisuite()
         command.main(args)
         self.assertGreater(os.listdir(app_path), 0)
-        self.verify_genproj('DotReaderLib17', 340, app_path)
+        self.verify_genproj('DotReaderLib17', 341, app_path)
 
     @integration_test
     def test_all_multisuite(self):
@@ -183,4 +183,4 @@ class TestBazelIntegration(unittest.TestCase):
         # Note we are assuming that the last project to be generated is the dot project.
         # If you change the order of project generation, make this match whatever is the new 'last project'
         # It's a bit fragile, but it's better than not verifying anything currently
-        self.verify_genproj('DotReaderLib17', 340, app_path)
+        self.verify_genproj('DotReaderLib17', 341, app_path)

--- a/tests/test_buck_integration.py
+++ b/tests/test_buck_integration.py
@@ -31,14 +31,14 @@ from .utils import integration_test, read_file
 
 class TestBuckIntegration(unittest.TestCase):
 
-    def verify_genproj(self, lib_name, mod_count, app_path):
+    def verify_genproj(self, lib_name, file_count, app_path):
         main_path = join(app_path, 'App')
         lib_path = join(app_path, lib_name, 'Sources')
 
         # Top level dir
         contents = os.listdir(app_path)
         self.assertGreater(len(contents), 0)
-        self.assertEqual(len(contents), mod_count)
+        self.assertEqual(len(contents), file_count)
 
         # App dir
         self.assertIn('App', contents)
@@ -69,7 +69,7 @@ class TestBuckIntegration(unittest.TestCase):
         command = GenProjCommandLine()
         command.main(args)
 
-        self.verify_genproj('MockLib53', 102, app_path)
+        self.verify_genproj('MockLib53', 103, app_path)
 
     @integration_test
     def test_dot_genproj(self):
@@ -83,7 +83,7 @@ class TestBuckIntegration(unittest.TestCase):
         command = GenProjCommandLine()
         command.main(args)
 
-        self.verify_genproj('DotReaderLib17', 339, app_path)
+        self.verify_genproj('DotReaderLib17', 340, app_path)
 
     @integration_test
     def test_dot_genproj_with_loc_mappings(self):
@@ -99,7 +99,7 @@ class TestBuckIntegration(unittest.TestCase):
         command = GenProjCommandLine()
         command.main(args)
 
-        self.verify_genproj('DotReaderLib17', 340, app_path)
+        self.verify_genproj('DotReaderLib17', 341, app_path)
 
     @integration_test
     def test_flat_multisuite(self):
@@ -110,7 +110,7 @@ class TestBuckIntegration(unittest.TestCase):
         command = CommandLineMultisuite()
         command.main(args)
         self.assertGreater(os.listdir(app_path), 0)
-        self.verify_genproj('MockLib53', 102, app_path)
+        self.verify_genproj('MockLib53', 103, app_path)
 
     @integration_test
     def test_flat_multisuite_mocking_calls(self):
@@ -142,7 +142,7 @@ class TestBuckIntegration(unittest.TestCase):
                 mock_find.return_value = '/bin/ls'  # A non empty return value basically means "I found that executable"
                 CommandLineMultisuite().main(args)
                 self.assertGreater(os.listdir(app_path), 0)
-                self.verify_genproj('MockLib53', 102, app_path)
+                self.verify_genproj('MockLib53', 103, app_path)
 
     @integration_test
     def test_dot_multisuite(self):
@@ -157,7 +157,7 @@ class TestBuckIntegration(unittest.TestCase):
         command = CommandLineMultisuite()
         command.main(args)
         self.assertGreater(os.listdir(app_path), 0)
-        self.verify_genproj('DotReaderLib17', 339, app_path)
+        self.verify_genproj('DotReaderLib17', 340, app_path)
 
     @integration_test
     def test_all_multisuite(self):
@@ -176,4 +176,4 @@ class TestBuckIntegration(unittest.TestCase):
         # Note we are assuming that the last project to be generated is the dot project.
         # If you change the order of project generation, make this match whatever is the new 'last project'
         # It's a bit fragile, but it's better than not verifying anything currently
-        self.verify_genproj('DotReaderLib17', 339, app_path)
+        self.verify_genproj('DotReaderLib17', 340, app_path)

--- a/tests/test_cp_integration.py
+++ b/tests/test_cp_integration.py
@@ -31,14 +31,14 @@ from .utils import integration_test, read_file
 
 class TestCocoaPodsIntegration(unittest.TestCase):
 
-    def verify_genproj(self, lib_name, mod_count, app_path):
+    def verify_genproj(self, lib_name, file_count, app_path):
         main_path = join(app_path, 'App')
         lib_path = join(app_path, lib_name, 'Sources')
 
         # Top level dir
         contents = os.listdir(app_path)
         self.assertGreater(len(contents), 0)
-        self.assertEqual(len(contents), mod_count)
+        self.assertEqual(len(contents), file_count)
 
         # App dir
         self.assertIn('App', contents)
@@ -69,7 +69,7 @@ class TestCocoaPodsIntegration(unittest.TestCase):
         command = GenProjCommandLine()
         command.main(args)
 
-        self.verify_genproj('MockLib53', 102, app_path)
+        self.verify_genproj('MockLib53', 103, app_path)
 
     @integration_test
     def test_dot_genproj(self):
@@ -83,7 +83,7 @@ class TestCocoaPodsIntegration(unittest.TestCase):
         command = GenProjCommandLine()
         command.main(args)
 
-        self.verify_genproj('DotReaderLib17', 339, app_path)
+        self.verify_genproj('DotReaderLib17', 340, app_path)
 
     @integration_test
     def test_dot_genproj_with_loc_mappings(self):
@@ -100,7 +100,7 @@ class TestCocoaPodsIntegration(unittest.TestCase):
         command = GenProjCommandLine()
         command.main(args)
 
-        self.verify_genproj('DotReaderLib17', 340, app_path)
+        self.verify_genproj('DotReaderLib17', 341, app_path)
 
     @integration_test
     def test_flat_multisuite(self):
@@ -114,7 +114,7 @@ class TestCocoaPodsIntegration(unittest.TestCase):
         command = CommandLineMultisuite()
         command.main(args)
         self.assertGreater(os.listdir(app_path), 0)
-        self.verify_genproj('MockLib53', 102, app_path)
+        self.verify_genproj('MockLib53', 103, app_path)
 
     @integration_test
     def test_flat_multisuite_mocking_calls(self):
@@ -146,7 +146,7 @@ class TestCocoaPodsIntegration(unittest.TestCase):
                 mock_find.return_value = '/bin/ls'  # A non empty return value basically means "I found that executable"
                 CommandLineMultisuite().main(args)
                 self.assertGreater(os.listdir(app_path), 0)
-                self.verify_genproj('MockLib53', 102, app_path)
+                self.verify_genproj('MockLib53', 103, app_path)
 
     @integration_test
     def test_dot_multisuite(self):
@@ -161,7 +161,7 @@ class TestCocoaPodsIntegration(unittest.TestCase):
         command = CommandLineMultisuite()
         command.main(args)
         self.assertGreater(os.listdir(app_path), 0)
-        self.verify_genproj('DotReaderLib17', 339, app_path)
+        self.verify_genproj('DotReaderLib17', 340, app_path)
 
     @integration_test
     def test_all_multisuite(self):
@@ -181,4 +181,4 @@ class TestCocoaPodsIntegration(unittest.TestCase):
         # Note we are assuming that the last project to be generated is the dot project.
         # If you change the order of project generation, make this match whatever is the new 'last project'
         # It's a bit fragile, but it's better than not verifying anything currently
-        self.verify_genproj('DotReaderLib17', 339, app_path)
+        self.verify_genproj('DotReaderLib17', 340, app_path)

--- a/uberpoet/blazeprojectgen.py
+++ b/uberpoet/blazeprojectgen.py
@@ -14,6 +14,7 @@
 
 from __future__ import absolute_import
 
+import json
 import logging
 import shutil
 import tempfile
@@ -108,16 +109,20 @@ class BlazeProjectGenerator(object):
         if loc_json_file_path:
             loc_reader = locreader.LocFileReader()
             loc_reader.read_loc_file(loc_json_file_path)
-            module_index = {
-                n.name: self.gen_lib_module(n, loc_reader.loc_for_module(n.name)) for n in library_node_list
-            }
+            loc = loc_reader.loc_for_module(n.name)
+            module_index = {n.name: {"files": self.gen_lib_module(n, loc), "loc": loc} for n in library_node_list}
         else:
             total_code_units = 0
             for l in library_node_list:
                 total_code_units += l.code_units
 
             loc_per_unit = target_loc / total_code_units
-            module_index = {n.name: self.gen_lib_module(n, loc_per_unit) for n in library_node_list}
+            module_index = {
+                n.name: {
+                    "files": self.gen_lib_module(n, loc_per_unit),
+                    "loc": loc_per_unit
+                } for n in library_node_list
+            }
 
         app_module_dir = join(self.app_root, "App")
         makedir(app_module_dir)
@@ -143,6 +148,16 @@ class BlazeProjectGenerator(object):
             # Copy the LOC file into the generated project.
             shutil.copyfile(loc_json_file_path, join(self.app_root, basename(loc_json_file_path)))
 
+        serializable_module_index = {
+            key: {
+                "file_count": len(value["files"]),
+                "loc": value["loc"]
+            } for key, value in module_index.items()
+        }
+
+        with open(join(self.app_root, "module_index.json"), "w") as module_index_json_file:
+            json.dump(serializable_module_index, module_index_json_file)
+
     def gen_app_build(self, node, all_nodes):
         module_dep_list = self.make_dep_list([i.name for i in node.deps])
         module_scheme_list = self.make_scheme_list([i.name for i in all_nodes])
@@ -150,7 +165,7 @@ class BlazeProjectGenerator(object):
 
     def gen_app_main(self, app_node, module_index):
         importing_module_name = app_node.deps[0].name
-        file_index = first_in_dict(module_index[importing_module_name])
+        file_index = first_in_dict(module_index[importing_module_name]["files"])
         class_key = first_key(file_index.classes)
         class_index = first_in_dict(file_index.classes)
         function_key = class_index[0]


### PR DESCRIPTION
This creates a new file `module_index.json` and prints it out to the generated project. The file includes information about each module that was generated so it can easily be inspected or parsed by other programs.

The file for now includes the LOC for each module as well as the file count associated with each module.